### PR TITLE
feat: model auto load after training

### DIFF
--- a/docker/Dockerfile.botfront
+++ b/docker/Dockerfile.botfront
@@ -78,10 +78,8 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # the entry point
 EXPOSE 5005
-ENTRYPOINT ["bash"]
 
-CMD -c \
-  "rasa run \
-  $([ -n \"$MODEL_PATH\" ] && echo \"-m $MODEL_PATH\") \
-  $([ -n \"$AUTH_TOKEN\" ] && echo \"--auth-token $AUTH_TOKEN\" ) \
-  --enable-api --debug"
+CMD rasa run \
+  $([ -n "$MODEL_PATH" ] && echo "-m $MODEL_PATH") \
+  $([ -n "$AUTH_TOKEN" ] && echo "--auth-token $AUTH_TOKEN" ) \
+  --enable-api --debug

--- a/docker/Dockerfile.botfront
+++ b/docker/Dockerfile.botfront
@@ -79,4 +79,9 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # the entry point
 EXPOSE 5005
 ENTRYPOINT ["bash"]
-CMD ["-c", "rasa run -m models/model-$BF_PROJECT_ID.tar.gz $([ -z \"$AUTH_TOKEN\" ] && echo \"\" || echo \"--auth-token $AUTH_TOKEN\" ) --enable-api --debug"]
+
+CMD -c \
+  "rasa run \
+  $([ -n \"$MODEL_PATH\" ] && echo \"-m $MODEL_PATH\") \
+  $([ -n \"$AUTH_TOKEN\" ] && echo \"--auth-token $AUTH_TOKEN\" ) \
+  --enable-api --debug"

--- a/rasa/server.py
+++ b/rasa/server.py
@@ -1006,10 +1006,12 @@ def create_app(
             "train your model.",
         )
 
+        load_model_after = request.args.get("load_model_after", False)
         if request.headers.get("Content-type") == YAML_CONTENT_TYPE:
             training_payload = _training_payload_from_yaml(request, temporary_directory)
         else:
             training_payload = _training_payload_from_json(request, temporary_directory)
+            load_model_after = request.json.get("load_model_after", load_model_after)
 
         try:
             with app.active_training_processes.get_lock():
@@ -1022,6 +1024,15 @@ def create_app(
 
             if training_result.model:
                 filename = os.path.basename(training_result.model)
+
+                if load_model_after is True:
+                    app.agent = await _load_agent(
+                        training_result.model,
+                        endpoints=endpoints,
+                        lock_store=app.agent.lock_store,
+                    )
+
+                    logger.debug(f"Successfully loaded model '{filename}'.")
 
                 return await response.file(
                     training_result.model,

--- a/rasa/server.py
+++ b/rasa/server.py
@@ -1648,7 +1648,7 @@ def _training_payload_from_json(
         domain=domain_path,
         config=config_paths,  # bf
         training_files=str(temp_dir),
-        output=model_output_directory,
+        output=os.environ.get("MODEL_PATH", DEFAULT_MODELS_PATH),  # bf
         force_training=request_payload.get(
             "force", request.args.get("force_training", False)
         ),

--- a/rasa/version.py
+++ b/rasa/version.py
@@ -1,4 +1,4 @@
 # this file will automatically be changed,
 # do not add anything but the version number here!
 __version__ = "2.3.3"
-__bf_patch__ = "-bf.2"
+__bf_patch__ = "-bf.3"

--- a/rasa_addons/importers/botfront.py
+++ b/rasa_addons/importers/botfront.py
@@ -47,6 +47,8 @@ class BotfrontFileImporter(TrainingDataImporter):
                 }
 
     def path_for_nlu_lang(self, lang) -> List[Text]:
+        if len(self.nlu_config.keys()) < 2:
+            return self._nlu_files
         return [x for x in self._nlu_files if f"nlu/{lang}" in x or f"nlu-{lang}" in x]
 
     async def get_config(self) -> Dict:

--- a/rasa_addons/setup.py
+++ b/rasa_addons/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="rasa_addons",
-    version="2.3.3.2",
+    version="2.3.3.3",
     author="Botfront",
     description="Rasa Addons - Components for Rasa and Botfront",
     install_requires=[


### PR DESCRIPTION
adds load_model_after param (default False) to /model/train route

allows MODEL_PATH env var for when one wants to use a path different than /app/models, which is declared as a volume and thus if unmounted will not be writable to